### PR TITLE
Likes stay after user is logged page

### DIFF
--- a/frontend/src/components/BathroomListings.jsx
+++ b/frontend/src/components/BathroomListings.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react'
 import {doc, getDoc, get, getDocs, collection} from 'firebase/firestore' 
-import { db } from '../firebase-config';
+import { db, auth } from '../firebase-config';
 import { query, where, orderBy } from "firebase/firestore";
 
 import BathroomRow from '../components/BathroomRow'
@@ -35,6 +35,7 @@ function getSortParam(param) {
 function BathroomListings(props) {
     const [bathroomList, setBathroomList] = useState([])
     const [topReviewTexts, setTopReviewTexts] = useState([])
+    const [favoritedBathrooms, setFavoritedBathrooms] = useState([])
     const [clear, setClear] = useState(false)
 
     useEffect(() => {
@@ -51,6 +52,25 @@ function BathroomListings(props) {
             setBathroomList(data.docs.map((doc) => ({...doc.data(), id: doc.id})))
         }
         getPosts()
+    },[db, props])
+
+    useEffect(() => {
+        const getFavorites = async () => {
+            console.log("made it here yipee!")
+            if (localStorage.getItem("isAuth")) { 
+                const userRef = collection(db, "users");
+                const q = query(userRef, where('id', '==', auth.currentUser.uid))
+                const snapshot = await getDocs(q)
+                const targetUser = doc(db, "users", snapshot.docs[0].id)
+                const docsSnap = await getDoc(targetUser)
+                setFavoritedBathrooms(docsSnap.data().likedBathrooms)
+                console.log("made it here yipee 2!")
+
+            }
+            else {
+            }
+        }
+        getFavorites()
     },[db, props])
 
     useEffect(() => {
@@ -91,7 +111,8 @@ function BathroomListings(props) {
     return <div className='bathroom-listings'>
 
     {bathroomList.map((entry, index) => {
-        let current_bathroom_row = <BathroomRow className='bathroom-entry' key={entry.name}
+        let current_bathroom_row = <BathroomRow className='bathroom-entry' 
+            key={entry.name}
             id={entry.id} 
             name={entry.name} 
             image={entry.image} 
@@ -103,6 +124,7 @@ function BathroomListings(props) {
             score_convenience={Math.round(entry.score_convenience * 10)/10}
             score_amenities={Math.round(entry.score_amenities * 10)/10}
             top_review={topReviewTexts[index]}
+            fav_list={favoritedBathrooms}
         />
         // console.log(entry.reviews[0])
         return current_bathroom_row

--- a/frontend/src/components/BathroomRow.jsx
+++ b/frontend/src/components/BathroomRow.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, useState } from 'react'
 import './BathroomRow.scss'
 import { getDocs, updateDoc, collection, arrayRemove, setDoc, doc, arrayUnion, query, where } from 'firebase/firestore'
 import { db, auth } from '../firebase-config';
@@ -28,8 +28,17 @@ export default class BathroomRow extends Component {
         const targetUser = doc(db, "users", snapshot.docs[0].id)
         await updateDoc(targetUser, {likedBathrooms: arrayRemove(this.props.id)})
     }
-
     var favorited = false;
+    console.log(this.props.fav_list)
+    if ((this.props.fav_list).includes(this.props.id)) {
+        // console.log("this is inside the check")
+        // console.log(this.props.id)
+        favorited = true;
+        // let displayImage = document.getElementById(button_id)
+        // displayImage.src = filledHeart
+        console.log(favorited)
+    }
+
     function whenClicked() {
         if (!localStorage.getItem("isAuth")) { 
             <link to ="/login"></link>
@@ -37,12 +46,12 @@ export default class BathroomRow extends Component {
         else {
             let displayImage = document.getElementById(button_id)
             if(!favorited) { 
-                favorited = true
+                favorited = true;
                 displayImage.src = filledHeart
                 addLikedBathroom()
             }
             else {
-                favorited = false
+                favorited = false;
                 displayImage.src = unfilledHeart
                 RemoveLikedBathroom()
             }
@@ -55,7 +64,6 @@ export default class BathroomRow extends Component {
         if (favorited == false) {
             event.target.src=filledHeart
         }        
-
     }
     const handleMouseOut = (event) => {
         if (favorited == false) {
@@ -106,7 +114,11 @@ export default class BathroomRow extends Component {
                 <img src='https://i.imgur.com/tqq4Q6I.png' onMouseOver= {handleMouseOver}onMouseOut= {handleMouseOut} alt='Unfilled Heart' class="profile"/>
                 </Link>
                 :
+                (!favorited ? 
                 <img id={button_id} src={unfilledHeart} onMouseOver= {handleMouseOver}onMouseOut= {handleMouseOut} onClick={() => {whenClicked()}} />
+                :                 <img id={button_id} src={filledHeart} onMouseOver= {handleMouseOver}onMouseOut= {handleMouseOut} onClick={() => {whenClicked()}} />
+                )
+
             }
 
         </div>


### PR DESCRIPTION
Added to both bathroomListings and BathroomRow to make sure the likes are saved on clicking back on the home. There is now an added prop that has all the user's likedBathroom if they're logged in